### PR TITLE
fix for daylight savings

### DIFF
--- a/dateparser.js
+++ b/dateparser.js
@@ -81,7 +81,8 @@ angular.module('dateParser', [])
                     ss = 0,
                     ampm = 'am',
                     now = new Date(),
-                    z = now.getTimezoneOffset() * -1;
+                    z = 0,
+                    parsedZ = false;
 
                 // TODO: Extract this into a helper function perhaps?
                 while (i_format < format.length) {
@@ -240,6 +241,7 @@ angular.module('dateParser', [])
                         var tzStr = val.substring(i_val, i_val + 5);
 
                         z = (parseInt(tzStr.substr(0, 3)) * 60) + parseInt(tzStr.substr(3, 2));
+                        parsedZ = true;
 
                         if (z > 720 || z < -720) {
                             throw 'Invalid timezone';
@@ -296,8 +298,11 @@ angular.module('dateParser', [])
                 }
 
                 var localDate = new Date(year, month - 1, date, hh, mm, ss);
-
-                return new Date(localDate.getTime() + (z + localDate.getTimezoneOffset()) * 60 * 1000);
+                if (parsedZ) {
+                    return new Date(localDate.getTime() + (z + localDate.getTimezoneOffset()) * 60 * 1000);
+                } else {
+                    return localDate;
+                }
             } catch(e) {
                 // TODO: Return undefined?
                 return new Date(undefined);


### PR DESCRIPTION
There was an issue when the date to parse is in ST (resp DT) and today is in DT (resp ST), when there is no 'Z' in the format.

Here is the output in Chrome's console:

``` sh
> new Date()
Fri Apr 11 2014 12:41:18 GMT+0200 (Paris, Madrid (heure d’été))
> new Date(2001, 0, 1, 12, 0)
Mon Jan 01 2001 12:00:00 GMT+0100 (Paris, Madrid)
> angular.element(document).injector().get("$dateParser")('2014-04-11 12:00', 'yyyy-MM-dd HH:mm')
Fri Apr 11 2014 12:00:00 GMT+0200 (Paris, Madrid (heure d’été))
> angular.element(document).injector().get("$dateParser")('2001-01-01 12:00', 'yyyy-MM-dd HH:mm')
Mon Jan 01 2001 13:00:00 GMT+0100 (Paris, Madrid)
```

The last one is parsed as "13:00" when it should be parsed as "12:00".
